### PR TITLE
New param to not strip the backgrounds

### DIFF
--- a/app/src/routes/api/v1/webshot.router.js
+++ b/app/src/routes/api/v1/webshot.router.js
@@ -62,7 +62,11 @@ class WebshotRouter {
       await page.goto(ctx.query.url, gotoOptions);
       if (delay) await page.waitFor(delay);
       if (ctx.query.mediatype) await page.emulateMedia(ctx.query.mediatype);
-      await page.pdf({ path: filePath, format: 'A4' });
+
+      // Whether or not to include the background
+      const printBackground = !!(ctx.query.backgrounds && ctx.query.backgrounds === 'true');
+
+      await page.pdf({ path: filePath, format: 'A4', printBackground });
 
       browser.close();
 


### PR DESCRIPTION
This PR adds a new parameter to the endpoint: `backgrounds`. When set to `true`, [puppeteer](https://github.com/GoogleChrome/puppeteer) will not strip the backgrounds.

This solves issues in several projects where the legend of the charts are not correctly displayed in the PDFs:
<p align="center">
<img width="1279" alt="On the right, a PDF of a pie chart whose legend doesn't show the colours. On the left, a PDF of the same pie chart where the legend displays the colours." src="https://user-images.githubusercontent.com/6073968/44198789-30944a80-a13a-11e8-89b9-ff6c4336bd99.png">
</p>

This task is based of [this PR](https://github.com/Vizzuality/webshot-pdf-export-service/pull/1).

## Testing instructions
1. Run the server locally. Let's say on port 8000.
2. Open this URL: http://localhost:8000/api/v1/webshot?filename=without-backgrounds&width=790&height=580&waitFor=8000&url=https://staging.prepdata.org/embed/widget/2d35e915-2cd7-4892-8288-aae9dfb982ec
3. Also open this one: http://localhost:8000/api/v1/webshot?filename=with-backgrounds&width=790&height=580&waitFor=8000&backgrounds=true&url=https://staging.prepdata.org/embed/widget/2d35e915-2cd7-4892-8288-aae9dfb982ec

The browser should download two PDFs:
- `without-backgrounds.pdf`: the legend of the pie chart is incorrectly displayed
- `with-backgrounds.pdf`: the legend of the pie chart is correctly displayed

## Pivotal
Not tracked, but blocking for [this task](https://www.pivotaltracker.com/story/show/159172219).
