### PR TITLE
Update local docker setup so it builds and registers with the Control Tower correctly

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,3 @@
-CT_URL=(URL of your control tower installation, leave empty in native usage)
-NODE_ENV=(prod|staging|dev)
-PORT=(port in which to run the application)
+CT_URL=http://mymachine:9000
+NODE_ENV=dev
+PORT=5000

--- a/base.yml
+++ b/base.yml
@@ -1,0 +1,8 @@
+base:
+  build: .
+  ports:
+    - "5000:5000"
+  container_name: webshot
+  environment:
+    PORT: 5000
+    NODE_PATH: app/src


### PR DESCRIPTION
I have made a series of small changes which ensures that the microservices build and register with the Control Tower locally with Docker.

The changes to this repo are:
- Set default config to real, working values
- Add missing `base.yml`