### PR TITLE
adds layer thumbnail endpoint + tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 npm-debug.log
 .nyc_output
 coverage
+.eslintcache

--- a/app/test/e2e/layer-thumbnail-post.spec.js
+++ b/app/test/e2e/layer-thumbnail-post.spec.js
@@ -46,7 +46,7 @@ describe('POST layer/:layer/thumbnail', () => {
     });
 
     it('If uploading to S3 fails returns 500 Internal Server Error', async () => {
-        stubPuppeteer(sinonSandbox, 'https://resourcewatch.org/webshot/layer/123');
+        stubPuppeteer(sinonSandbox, 'https://resourcewatch.org/webshot/layer/123?');
         stubS3(sinonSandbox, 'http://www.example.com', false);
 
         const response = await requester.post(`/api/v1/webshot/layer/123/thumbnail`).send();

--- a/app/test/e2e/layer-thumbnail-post.spec.js
+++ b/app/test/e2e/layer-thumbnail-post.spec.js
@@ -22,7 +22,9 @@ describe('POST layer/:layer/thumbnail', () => {
         requester = await getTestServer();
     });
 
-    beforeEach(() => { sinonSandbox = sinon.createSandbox(); });
+    beforeEach(() => {
+        sinonSandbox = sinon.createSandbox();
+    });
 
     it('Takes a snapshot of the layer returning 200 OK with the URL for the screenshot (happy case)', async () => {
         stubPuppeteer(sinonSandbox, 'https://resourcewatch.org/webshot/layer/123?');

--- a/app/test/e2e/layer-thumbnail-post.spec.js
+++ b/app/test/e2e/layer-thumbnail-post.spec.js
@@ -1,0 +1,66 @@
+const chai = require('chai');
+const nock = require('nock');
+const sinon = require('sinon');
+
+const { getTestServer } = require('./utils/test-server');
+const { stubPuppeteer, stubS3 } = require('./utils/stubs');
+
+chai.should();
+
+let requester;
+let sinonSandbox;
+
+nock.disableNetConnect();
+nock.enableNetConnect(process.env.HOST_IP);
+
+describe('POST layer/:layer/thumbnail', () => {
+    before(async () => {
+        if (process.env.NODE_ENV !== 'test') {
+            throw Error(`Running the test suite with NODE_ENV ${process.env.NODE_ENV} may result in permanent data loss. Please use NODE_ENV=test.`);
+        }
+
+        requester = await getTestServer();
+    });
+
+    beforeEach(() => { sinonSandbox = sinon.createSandbox(); });
+
+    it('Takes a snapshot of the layer returning 200 OK with the URL for the screenshot (happy case)', async () => {
+        stubPuppeteer(sinonSandbox, 'https://resourcewatch.org/webshot/layer/123?');
+        stubS3(sinonSandbox, 'http://www.example.com');
+
+        const response = await requester.post(`/api/v1/webshot/layer/123/thumbnail`).send();
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('object');
+        response.body.data.should.have.property('layerThumbnail').and.equal('http://www.example.com');
+    });
+
+    it('If puppeteer fails taking the screenshot returns 400 Internal Server Error', async () => {
+        stubPuppeteer(sinonSandbox, false);
+        stubS3(sinonSandbox, 'http://www.example.com');
+
+        const response = await requester.post(`/api/v1/webshot/layer/123/thumbnail`).send();
+        response.status.should.equal(400);
+        response.body.should.have.property('errors').and.be.an('array');
+        response.body.errors[0].should.have.property('status').and.equal(400);
+        response.body.errors[0].should.have.property('detail').and.include('Error taking screenshot on URL');
+    });
+
+    it('If uploading to S3 fails returns 500 Internal Server Error', async () => {
+        stubPuppeteer(sinonSandbox, 'https://resourcewatch.org/webshot/layer/123');
+        stubS3(sinonSandbox, 'http://www.example.com', false);
+
+        const response = await requester.post(`/api/v1/webshot/layer/123/thumbnail`).send();
+        response.status.should.equal(500);
+        response.body.should.have.property('errors').and.be.an('array');
+        response.body.errors[0].should.have.property('status').and.equal(500);
+        response.body.errors[0].should.have.property('detail').and.include('Error uploading screenshot to S3');
+    });
+
+    afterEach(() => {
+        if (!nock.isDone()) {
+            throw new Error(`Not all nock interceptors were used: ${nock.pendingMocks()}`);
+        }
+
+        sinonSandbox.restore();
+    });
+});

--- a/app/test/e2e/webshot-screenshot-post.spec.js
+++ b/app/test/e2e/webshot-screenshot-post.spec.js
@@ -20,7 +20,9 @@ describe('Screenshot endpoint', () => {
         }
     });
 
-    beforeEach(() => { sinonSandbox = sinon.createSandbox(); });
+    beforeEach(() => {
+        sinonSandbox = sinon.createSandbox();
+    });
 
     describe('happy case', () => {
         it('Takes a screenshot of the widget returning 200 OK with the URL for the pdf', async () => {

--- a/app/test/e2e/widget-thumbnail-post.spec.js
+++ b/app/test/e2e/widget-thumbnail-post.spec.js
@@ -22,7 +22,9 @@ describe('POST widget/:widget/thumbnail', () => {
         requester = await getTestServer();
     });
 
-    beforeEach(() => { sinonSandbox = sinon.createSandbox(); });
+    beforeEach(() => {
+        sinonSandbox = sinon.createSandbox();
+    });
 
     it('Takes a snapshot of the widget returning 200 OK with the URL for the screenshot (happy case)', async () => {
         stubPuppeteer(sinonSandbox, 'https://resourcewatch.org/webshot/123?');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1689,7 +1689,7 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-"fastly-promises@github:tiagojsag/fastly-promises#master":
+fastly-promises@tiagojsag/fastly-promises#master:
   version "0.0.0-semantically-released"
   resolved "https://codeload.github.com/tiagojsag/fastly-promises/tar.gz/6c68b9c01e2706a51f960d745ac7611be2c1a006"
   dependencies:


### PR DESCRIPTION
Adds `/webshot/layer/[id]` endpoint to generate a thumbnail based on a [layer](https://resource-watch.github.io/doc-api/reference.html#layer).

The endpoint admits any query params and will concatenate them to the application's endpoint as well.